### PR TITLE
Added in-docker multi-stage build to make it easier to run on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
+FROM golang as build
+
+WORKDIR /go/src/app
+RUN apt-get update && apt-get install -y openssl libssl-dev
+COPY nrpe_exporter.go .
+RUN go get -d -v ./...
+RUN go build -o nrpe_exporter .
+
+# Multi-stage-build
 FROM alpine:latest
 
 RUN apk update && apk add --no-cache openssl
 
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
-COPY nrpe_exporter  /bin/nrpe_exporter
+COPY --from=build /go/src/app/nrpe_exporter /bin/nrpe_exporter
 
 EXPOSE      9275
 ENTRYPOINT  [ "/bin/nrpe_exporter" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
-FROM golang as build
+FROM ubuntu:16.04 as build
 
+ENV GOPATH=/go
 WORKDIR /go/src/app
-RUN apt-get update && apt-get install -y openssl libssl-dev
-COPY nrpe_exporter.go .
-RUN go get -d -v ./...
-RUN go build -o nrpe_exporter .
+RUN apt-get update && apt-get install -y openssl libssl-dev curl git build-essential pkg-config golang
 
-# Multi-stage-build
+RUN go get golang.org/dl/go1.15
+RUN /go/bin/go1.15 download
+RUN ln -sf /go/bin/go1.15 /usr/bin/go
+
+COPY . .
+
+RUN make buildstatic
+
 FROM alpine:latest
-
-RUN apk update && apk add --no-cache openssl
-
-RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
 COPY --from=build /go/src/app/nrpe_exporter /bin/nrpe_exporter
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+# Copyright 2015 The Prometheus Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GO    := GO15VENDOREXPERIMENT=1 go
+pkgs   = $(shell $(GO) list ./... | grep -v /vendor/)
+
+PREFIX                  ?= $(shell pwd)
+BIN_DIR                 ?= $(shell pwd)
+DOCKER_REPO             ?= robustperception
+BUILD_NAME              ?= nrpe_exporter
+DOCKER_IMAGE_NAME       ?= nrpe_exporter
+DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
+
+all: format build test
+
+test: build
+	@echo ">> running tests"
+	@$(GO) test -short $(pkgs)
+
+style:
+	@echo ">> checking code style"
+	@! gofmt -d $(shell find . -path ./vendor -prune -o -name '*.go' -print) | grep '^'
+
+format:
+	@echo ">> formatting code"
+	@$(GO) fmt $(pkgs)
+
+vet:
+	@echo ">> vetting code"
+	@$(GO) vet $(pkgs)
+
+build:
+	@echo ">> building binaries"
+	@$(GO) build -o "$(BUILD_NAME)" .
+
+buildstatic:
+	@echo ">> building binaries"
+	@$(GO) build -a -ldflags '-extldflags "-static -ldl"' -o "$(BUILD_NAME)" .
+
+docker:
+	@echo ">> building docker image"
+	@docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+
+.PHONY: all style format build test vet tarball docker buildstatic

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The NRPE exporter exposes metrics on commands sent to a running NRPE daemon.
 Visiting [http://localhost:9275/export?command=check_load&target=127.0.0.1:5666](http://localhost:9275/export?command=check_load&target=127.0.0.1:5666)
 will return metrics for the command 'check_load' against a locally running NRPE server.
 
-### Building with Docker
+### Building with Docker (with SSL support)
 
     docker build -t nrpe_exporter .
     docker run -d -p 9275:9275 --name nrpe_exporter


### PR DESCRIPTION
The current build instructions expects the implementer to have a local Golang installation. To make it easier to start the image in Docker on a server without a Golang installation, the Dockerfile was updated to add a build step.

In the hope it's helpful.

All the best//Philippe